### PR TITLE
Simplify error parsing

### DIFF
--- a/harness/aoc/kernel/harness.go
+++ b/harness/aoc/kernel/harness.go
@@ -87,7 +87,7 @@ func Harness() error {
 		file += ".txt"
 		if err := x.CreateFunc(file, func() (string, error) {
 			codeBlock := "```"
-			re := regexp.MustCompile(`(?m)(For|Here is an) example.*:\n+` + codeBlock + `\n((.*\n)+?)\n?` + codeBlock + `\n`)
+			re := regexp.MustCompile(`(?m)(E|e)xample.*:\n+` + codeBlock + `\n((.*\n)+?)\n?` + codeBlock + `\n`)
 			matches := re.FindAllStringSubmatch(readme, -1)
 			if len(matches) == 0 {
 				return "", errors.New("no examples found in README.md")


### PR DESCRIPTION
Simplify error regex for better chance
of parsing. This years AOC has been varying
somewhat in their example verbiage.

Fixes #2